### PR TITLE
fix: Replace OpenDyslexic with Comic Neue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@auth/prisma-adapter": "^2.10.0",
 				"@auth/sveltekit": "^1.10.0",
-				"@fontsource/opendyslexic": "^5.2.5",
+				"@fontsource/comic-neue": "^5.2.6",
 				"@lexical/clipboard": "0.33.1",
 				"@lexical/code": "0.33.1",
 				"@lexical/file": "0.33.1",
@@ -746,10 +746,10 @@
 				"heap": ">= 0.2.0"
 			}
 		},
-		"node_modules/@fontsource/opendyslexic": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/@fontsource/opendyslexic/-/opendyslexic-5.2.5.tgz",
-			"integrity": "sha512-NNS9aaPQx2TlaTvb3vTEjw3xz8lKj23mBc+6rM00mSNFDygdoll0/nLMHFtDKKrBT6sMfY6TFFPOR0D9ktdspg==",
+		"node_modules/@fontsource/comic-neue": {
+			"version": "5.2.6",
+			"resolved": "https://registry.npmjs.org/@fontsource/comic-neue/-/comic-neue-5.2.6.tgz",
+			"integrity": "sha512-FhI/0GU20Dgv/7K50UqyFSNAThevYk2hDv9D9UFYYd3HaGJxH82ujtssJD5am36kxy6nFlSM8rafL3lEoSshJQ==",
 			"license": "OFL-1.1",
 			"funding": {
 				"url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 	"dependencies": {
 		"@auth/prisma-adapter": "^2.10.0",
 		"@auth/sveltekit": "^1.10.0",
-		"@fontsource/opendyslexic": "^5.2.5",
+		"@fontsource/comic-neue": "^5.2.6",
 		"@lexical/clipboard": "0.33.1",
 		"@lexical/code": "0.33.1",
 		"@lexical/file": "0.33.1",

--- a/src/app.css
+++ b/src/app.css
@@ -1,9 +1,9 @@
-@import "@fontsource/opendyslexic";
+@import "@fontsource/comic-neue";
 
 @import "tailwindcss";
 
 @theme {
-  --font-dyslexic: 'OpenDyslexic, \'Comic Sans MS\', arial, helvetica, sans-serif'
+  --font-dyslexic: '\'Comic Neue\', \'Comic Sans MS\', arial, helvetica, sans-serif'
 }
 
 @plugin "@tailwindcss/forms";

--- a/src/lib/components/editor/toolbar/FontSelect.svelte
+++ b/src/lib/components/editor/toolbar/FontSelect.svelte
@@ -99,6 +99,6 @@
 		<option value="mixed" hidden>Mixed</option>
 		<option value="" class="font-sans text-lg">Default font</option>
 		<option value="monospace" class="font-mono text-lg">Monospace</option>
-		<option value="OpenDyslexic" class="font-dyslexic text-lg">OpenDyslexic</option>
+		<option value="Comic Neue" class="font-dyslexic text-lg">Comic Neue</option>
 	</Select>
 </div>

--- a/src/lib/constants/text.js
+++ b/src/lib/constants/text.js
@@ -1,7 +1,7 @@
 const FONTFAMILIES = Object.freeze({
 	default: '',
 	Monospace: 'monospace',
-	OpenDyslexic: 'OpenDyslexic',
+	ComicNeue: 'Comic Neue',
 });
 
 export const TEXT_CONSTANTS = {


### PR DESCRIPTION
Existing usage of OpenDyslexic will just use default font. That's ok.