### PR TITLE
fix search button style

### DIFF
--- a/src/lib/components/Search.svelte
+++ b/src/lib/components/Search.svelte
@@ -23,7 +23,7 @@
 		bind:value={query}
 	/>
 
-	<Button type="submit" class="h-full rounded-l-none rounded-r-sm">
+	<Button type="submit" class="forsen-wiki-theme-border h-full !rounded-l-none border">
 		<SearchIcon />
 		<span class="hidden">Search</span>
 	</Button>


### PR DESCRIPTION
site was unusable, this should fix it :)

before 
<img width="1065" height="134" alt="image" src="https://github.com/user-attachments/assets/07f8dcaf-5f44-4f67-8000-b1e9441b25db" />


after 
<img width="1063" height="134" alt="image" src="https://github.com/user-attachments/assets/6bbff691-709f-4952-aa52-e1d4779496df" />


I did not test this because I couldn't get the project to build :)