### PR TITLE
feat(VideoEmbed): Experimental browser lazy load

### DIFF
--- a/src/lib/components/editor/plugins/VideoEmbed/VideoEmbed.ts
+++ b/src/lib/components/editor/plugins/VideoEmbed/VideoEmbed.ts
@@ -366,8 +366,10 @@ function generateCDNSrc(node: VideoEmbedNode, staticURL: string) {
 	setVideoAttributes(node, element);
 	element.setAttribute('controls', '');
 	element.setAttribute('data-lexical-usercontent', node.getSrc()!);
+	element.setAttribute('loading', 'lazy');
 
 	element.controls = true;
+	element.playsInline = true;
 
 	const source = document.createElement('source');
 	source.src = url;

--- a/src/lib/components/editor/plugins/VideoEmbed/VideoEmbedComponent.svelte
+++ b/src/lib/components/editor/plugins/VideoEmbed/VideoEmbedComponent.svelte
@@ -235,6 +235,7 @@
 					{width}
 					{height}
 					style={getIframeStyle(width, height)}
+					loading="lazy"
 				>
 					<source
 						src={url}


### PR DESCRIPTION
Experimental browser feature, won't work in Firefox.
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video#loading

Needs a proper solution later.